### PR TITLE
Add single file status with --file-changed argument in collection-status mode

### DIFF
--- a/bin/duplicity
+++ b/bin/duplicity
@@ -458,6 +458,7 @@ def write_multivol(backup_type, tarblock_iter, man_outfp, sig_outfp, backend):
 
     # Upload the collection summary.
     # bytes_written += write_manifest(mf, backup_type, backend)
+    mf.set_files_changed_info(diffdir.stats.get_delta_entries_file())
 
     return bytes_written
 
@@ -1450,7 +1451,10 @@ def do_backup(action):
     elif action == "list-current":
         list_current(col_stats)
     elif action == "collection-status":
-        log.PrintCollectionStatus(col_stats, True)
+        if not globals.file_changed:
+            log.PrintCollectionStatus(col_stats, True)
+        else:
+            log.PrintCollectionFileChangedStatus(col_stats, globals.file_changed, True)
     elif action == "cleanup":
         cleanup(col_stats)
     elif action == "remove-old":

--- a/bin/duplicity.1
+++ b/bin/duplicity.1
@@ -21,7 +21,7 @@ source_directory target_url
 source_url target_directory
 
 .B duplicity collection-status
-.I [options]
+.I [options] [--file-changed <relpath>]
 target_url
 
 .B duplicity list-current-files
@@ -180,7 +180,7 @@ The
 option enables data comparison (see below).
 
 .TP
-.BI "collection-status " "<url>"
+.BI "collection-status " "[--file-changed <relpath>]" "<url>"
 Summarize the status of the backup repository by printing the chains
 and sets found, and the number of volumes in each.
 
@@ -421,6 +421,15 @@ use --extra-clean unless you know what you're doing.
 See the
 .B cleanup
 argument for more information.
+
+.TP
+.BI "--file-changed " path
+This option may be given in collection-status mode, causing only
+.I path
+status to be collect instead of the entire contents of the backup archive.
+.I path
+should be given relative to the root of the directory backed up.
+
 
 .TP
 .BI "--file-prefix, --file-prefix-manifest, --file-prefix-archive, --file-prefix-signature

--- a/duplicity/commandline.py
+++ b/duplicity/commandline.py
@@ -614,6 +614,11 @@ def parse_cmdline_options(arglist):
     parser.add_option("--volsize", type="int", action="callback", metavar=_("number"),
                       callback=lambda o, s, v, p: setattr(p.values, "volsize", v * 1024 * 1024))
 
+    # If set, collect only the file status, not the whole root.
+    parser.add_option("--file-changed", action="callback", type="file",
+                      metavar=_("path"), dest="file_changed",
+                      callback=lambda o, s, v, p: setattr(p.values, "file_changed", v.rstrip('/')))
+
     # parse the options
     (options, args) = parser.parse_args()
 

--- a/duplicity/diffdir.py
+++ b/duplicity/diffdir.py
@@ -209,7 +209,7 @@ def get_delta_iter(new_iter, sig_iter, sig_fileobj=None):
                     ti = ROPath(sig_path.index).get_tarinfo()
                     ti.name = "deleted/" + "/".join(sig_path.index)
                     sigTarFile.addfile(ti)
-                stats.add_deleted_file()
+                stats.add_deleted_file(sig_path)
                 yield ROPath(sig_path.index)
         elif not sig_path or new_path != sig_path:
             # Must calculate new signature and create delta

--- a/duplicity/globals.py
+++ b/duplicity/globals.py
@@ -284,3 +284,6 @@ par2_options = ""
 
 # Whether to enable gio backend
 use_gio = False
+
+# If set, collect only the file status, not the whole root.
+file_changed = None

--- a/duplicity/log.py
+++ b/duplicity/log.py
@@ -219,6 +219,10 @@ def PrintCollectionStatus(col_stats, force_print=False):
     Log(unicode(col_stats), 8, InfoCode.collection_status,
         '\n' + '\n'.join(col_stats.to_log_info()), force_print)
 
+def PrintCollectionFileChangedStatus(col_stats, filepath, force_print=False):
+    """Prints a collection status to the log"""
+    Log(unicode(col_stats.get_file_changed_record(filepath)), 8, InfoCode.collection_status, None, force_print)
+
 
 def Notice(s):
     """Shortcut used for notice messages (verbosity 3, the default)."""

--- a/duplicity/statistics.py
+++ b/duplicity/statistics.py
@@ -306,6 +306,7 @@ class StatsDeltaProcess(StatsObj):
             self.__dict__[attr] = 0
         self.Errors = 0
         self.StartTime = time.time()
+        self.files_changed = []
 
     def add_new_file(self, path):
         """Add stats of new file path to statistics"""
@@ -315,6 +316,7 @@ class StatsDeltaProcess(StatsObj):
         self.NewFiles += 1
         self.NewFileSize += filesize
         self.DeltaEntries += 1
+        self.add_delta_entries_file(path)
 
     def add_changed_file(self, path):
         """Add stats of file that has changed since last backup"""
@@ -324,11 +326,13 @@ class StatsDeltaProcess(StatsObj):
         self.ChangedFiles += 1
         self.ChangedFileSize += filesize
         self.DeltaEntries += 1
+        self.add_delta_entries_file(path)
 
-    def add_deleted_file(self):
+    def add_deleted_file(self, path):
         """Add stats of file no longer in source directory"""
         self.DeletedFiles += 1  # can't add size since not available
         self.DeltaEntries += 1
+        self.add_delta_entries_file(path)
 
     def add_unchanged_file(self, path):
         """Add stats of file that hasn't changed since last backup"""
@@ -339,3 +343,10 @@ class StatsDeltaProcess(StatsObj):
     def close(self):
         """End collection of data, set EndTime"""
         self.EndTime = time.time()
+
+    def add_delta_entries_file(self, path):
+        if path.isreg():
+            self.files_changed.append(path.get_relative_path())
+
+    def get_delta_entries_file(self):
+        return self.files_changed


### PR DESCRIPTION
```
duplicity collection-status --file-changed c1  --archive-dir=./b/sigs file://./b
Local and Remote metadata are synchronized, no sync needed.
Last full backup date: Thu May  7 17:25:01 2015
-------------------------
File path: c1
Total number of backup: 4
 Type of backup set:                            Time:
                Full         Thu May  7 17:25:01 2015
         Incremental         Thu May  7 17:25:16 2015
         Incremental         Thu May  7 17:25:24 2015
         Incremental         Thu May  7 17:25:27 2015
-------------------------
```