### PR TITLE
Add --azure-region to support Azure Germany and Azure China

### DIFF
--- a/duplicity/backends/azurebackend.py
+++ b/duplicity/backends/azurebackend.py
@@ -59,17 +59,26 @@ Exception: %s""" % str(e))
 
         # TODO: validate container name
         self.container = parsed_url.path.lstrip('/')
+        
+        if globals.azure_region == 'global':
+            suffix = "core.windows.net"
+        elif globals.azure_region == 'germany':
+            suffix = "core.cloudapi.de"
+        elif globals.azure_region == 'china':
+            suffix = "core.chinacloudapi.cn"
 
         if 'AZURE_ACCOUNT_NAME' not in os.environ:
             raise BackendException('AZURE_ACCOUNT_NAME environment variable not set.')
 
         if 'AZURE_ACCOUNT_KEY' in os.environ:
             self.blob_service = BlobService(account_name=os.environ['AZURE_ACCOUNT_NAME'],
-                                            account_key=os.environ['AZURE_ACCOUNT_KEY'])
+                                            account_key=os.environ['AZURE_ACCOUNT_KEY'],
+                                            endpoint_suffix=suffix)
             self._create_container()
         elif 'AZURE_SHARED_ACCESS_SIGNATURE' in os.environ:
             self.blob_service = BlobService(account_name=os.environ['AZURE_ACCOUNT_NAME'],
-                                            sas_token=os.environ['AZURE_SHARED_ACCESS_SIGNATURE'])
+                                            sas_token=os.environ['AZURE_SHARED_ACCESS_SIGNATURE'],
+                                            endpoint_suffix=suffix)
         else:
             raise BackendException(
                 'Neither AZURE_ACCOUNT_KEY nor AZURE_SHARED_ACCESS_SIGNATURE environment variable not set.')

--- a/duplicity/commandline.py
+++ b/duplicity/commandline.py
@@ -580,6 +580,9 @@ def parse_cmdline_options(arglist):
     # The number for the maximum parallel connections to use when the blob size exceeds 64MB.
     # max_connections (int) - Maximum number of parallel connections to use when the blob size exceeds 64MB.
     parser.add_option("--azure-max-connections", type="int", metavar=_("number"))
+    
+    # The used Azure region, for Azure Germany and Azure China they used different storage endpoints
+    parser.add_option("--azure-region", metavar=_("global|germany|china"))
 
     # scp command to use (ssh pexpect backend)
     parser.add_option("--scp-command", metavar=_("command"))

--- a/duplicity/globals.py
+++ b/duplicity/globals.py
@@ -228,6 +228,9 @@ azure_max_block_size = None
 # Maximum number of parallel connections to use when the blob size for azure exceeds 64MB
 azure_max_connections = None
 
+# The Azure Region
+azure_region = "global"
+
 # Whether to use the full email address as the user name when
 # logging into an imap server. If false just the user name
 # part of the email address is used.


### PR DESCRIPTION
With this modification duplicity can store the backup blobs on Azure Germany and Azure China Blob Storage, both Systems use different endpoint suffixes
